### PR TITLE
Add missing config dir option in example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,4 +15,4 @@ Getting started
 .. code::
 
   pip install .
-  synapse-config-generator config_dir
+  synapse-config-generator --configdir config_dir


### PR DESCRIPTION
```
$ synapse-config-generator config_dir                                                                                                            
usage: synapse-config-generator [-h] [--configdir CONFIG_DIR] [-v]
                                [--port PORT]
synapse-config-generator: error: unrecognized arguments: config_dir
$ synapse-config-generator --configdir config_dir
'config_dir' is not a directory.
```