### PR TITLE
Don't watch when running build

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -9,7 +9,7 @@ export default {
         './webui/scss/main.scss',
         './webui/scss/bootstrap.min.css',
     ],
-    watch: true,
+    watch: false,
     output: {
         path: path.resolve(__dirname, 'synapseconfiggenerator/static'),
         filename: 'bundle.js',


### PR DESCRIPTION
If `watch` is enabled, then running `npm run-script build` never exits (as it's simply just waiting for changes before rebuilding). This functionality is already provided by `npm run-script watch`, so there is no need for `build` to do the same thing.