### PR TITLE
Add "tests" conditional dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,8 @@ setup(
     scripts=["synapseconfiggenerator/synapse-config-generator"],
     packages=find_packages(),
     install_requires=REQUIREMENTS,
+    extras_require={
+        "tests": ["psutil>=5.7.2"],
+    },
     include_package_data=True,
 )

--- a/tests/test_config_generator.py
+++ b/tests/test_config_generator.py
@@ -1,5 +1,5 @@
 from twisted.trial import unittest
-from tempfile import TemporaryDirectory, TemporaryFile
+from tempfile import TemporaryDirectory
 from synapseconfiggenerator.model import Model
 from subprocess import check_output
 from psutil import Process


### PR DESCRIPTION
Adds a conditional dependency of "tests", which specifies all of the optional dependencies needed to run python tests.

Also removes an unused import in `test_config_generator.py`.